### PR TITLE
Sentry v7.0.0 workaround.

### DIFF
--- a/sentry_jira/plugin.py
+++ b/sentry_jira/plugin.py
@@ -253,7 +253,9 @@ class JIRAPlugin(IssuePlugin):
 
     def should_create(self, group, event, is_new):
 
-        if GroupMeta.objects.get_value(group, '%s:tid' % self.get_conf_key(), None):
+        GroupMeta.objects.populate_cache([group])  # temporary workaround
+
+        if GroupMeta.objects.get(group, '%s:tid' % self.get_conf_key(), None):
             return False
 
         auto_create = self.get_option('auto_create', group.project)

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ f.close()
 
 setup(
     name='sentry-jira',
-    version='0.8.2',
+    version='0.8.3',
     author='Adam Thurlow',
     author_email='thurloat@gmail.com',
     url='http://github.com/thurloat/sentry-jira',


### PR DESCRIPTION
GroupMeta started moving towards a cache model.  The problem is that it doesn't have a fallback mechanism if
the cache is empty.

https://github.com/getsentry/sentry/commit/7640827ee4733d23353eeff400c57eb814654d68